### PR TITLE
Add TrendRider to trading bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Thanks to all the [contributors](https://github.com/suenot/awesome-crypto-tradin
 - [ZenBot](https://github.com/carlos8f/zenbot) - A command-line cryptocurrency trading bot using Node.js and MongoDB.
 - [Titan](https://github.com/Denton24646/Titan) - Based on python, flask, postgres.
 - [Python-crypto-Bot](https://github.com/Seigneur774/Python-crypto-Bot)
+- [TrendRider](https://trendrider.net) - Multi-timeframe algo trading bot for Bybit with 67.9% win rate, dynamic position sizing, 15+ altcoins. #python, #freqtrade, #bybit
 
 ## Signals
 


### PR DESCRIPTION
Add [TrendRider](https://trendrider.net) — a free Freqtrade-based crypto trading bot.

- Engine: Freqtrade (#python)
- Exchange: Bybit
- Multi-timeframe analysis, 67.9% win rate
- Dynamic position sizing, 15+ altcoins
- Free & open source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added TrendRider trading bot entry to the documentation, featuring multi-timeframe algorithmic trading capabilities for Bybit with a 67.9% win rate, dynamic position sizing, and support for 15+ altcoins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->