### PR TITLE
Add Ezath to Signals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Thanks to all the [contributors](https://github.com/suenot/awesome-crypto-tradin
 
 - [Peregrine](https://github.com/wardbradt/peregrine) - Arbitrage on python.
 - [ccxt-arbitrage](https://github.com/ArthurAnanda/ccxt-arbitrage-v1)
+- [Ezath](https://ezath.com) - BTC/ETH/SOL signals with a public SHA-256 hash-chained track record (wins and losses); free risk/reward, liquidation and profit-factor calculators and an AI position-analysis scorer.
 
 ## Trading toolkits
 


### PR DESCRIPTION
Adds Ezath to the Signals section.

Ezath is a crypto trading signals service for BTC/ETH/SOL whose every signal is published to a publicly verifiable, SHA-256 hash-chained track record (wins and losses, no survivorship editing), plus free no-signup tools: risk/reward, liquidation and profit-factor calculators and an AI position-analysis scorer.

It fits alongside the hosted signal/bot services already listed (e.g. TrendRider, DeepAlpha). Single entry, description ends with a period per CONTRIBUTING.md. Thanks for maintaining the list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Ezath" entry to the signals directory, featuring BTC/ETH/SOL signal tracking with hash-chained track record verification and integrated calculators and scoring tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->